### PR TITLE
Add ability to specify custom package managers

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -238,6 +238,20 @@ $defaultConfig = @'
 # disabling unused ones will improve speed
 # $ShowPkgs = @("winget", "scoop", "choco")
 
+# Use the following option to specify custom package managers.
+# Create a function with that name as suffix, and which returns
+# the number of packages. Three examples are shown here:
+# $CustomPkgs = @("cargo", "pacman", "just-install")
+# function info_pkg_cargo {
+#     return (cargo install --list | Where-Object {$_ -like "*:" }).Length
+# }
+# function info_pkg_pacman {
+#     return (pacman -Qq).Length
+# }
+# function info_pkg_just-install {
+#     return (just-install list).Length
+# }
+
 # Configure how to show info for levels
 # Default is for text only.
 # 'bar' is for bar only.
@@ -693,6 +707,13 @@ function info_pkgs {
 
         if ($scooppkg) {
             $pkgs += "$scooppkg (scoop)"
+        }
+    }
+
+    foreach ($pkgitem in $CustomPkgs) {
+        if (Test-Path Function:"info_pkg_$pkgitem") {
+            $count = & "info_pkg_$pkgitem"
+            $pkgs += "$count ($pkgitem)"
         }
     }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -240,13 +240,10 @@ $defaultConfig = @'
 
 # Use the following option to specify custom package managers.
 # Create a function with that name as suffix, and which returns
-# the number of packages. Three examples are shown here:
-# $CustomPkgs = @("cargo", "pacman", "just-install")
+# the number of packages. Two examples are shown here:
+# $CustomPkgs = @("cargo", "just-install")
 # function info_pkg_cargo {
 #     return (cargo install --list | Where-Object {$_ -like "*:" }).Length
-# }
-# function info_pkg_pacman {
-#     return (pacman -Qq).Length
 # }
 # function info_pkg_just-install {
 #     return (just-install list).Length


### PR DESCRIPTION
We can't possibly support all package managers. Winget (official), Scoop and Choco are most reasonable defaults.

This PR adds the ability to plug custom package counts.

I'll update the Wiki page once this gets merged.


Closes #83