### PR TITLE
Change user, host, and rowname colors to yellow for better visibility

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -537,7 +537,7 @@ function info_motherboard {
 function info_title {
     return @{
         title   = ""
-        content = "${e}[1;34m{0}${e}[0m@${e}[1;34m{1}${e}[0m" -f [System.Environment]::UserName,$env:COMPUTERNAME
+        content = "${e}[1;33m{0}${e}[0m@${e}[1;33m{1}${e}[0m" -f [System.Environment]::UserName,$env:COMPUTERNAME
     }
 }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1001,7 +1001,7 @@ foreach ($item in $config) {
     }
 
     foreach ($line in $info) {
-        $output = "$e[1;34m$($line["title"])$e[0m"
+        $output = "$e[1;33m$($line["title"])$e[0m"
 
         if ($line["title"] -and $line["content"]) {
             $output += ": "


### PR DESCRIPTION
Dark blue on black is kind of hard to read.

![cmd-old-cropped-censored](https://user-images.githubusercontent.com/357902/126886633-20891cf4-09fb-4aab-b79c-d2e508d06d15.png)
[](url)

If you're actually using the old powershell terminal with its default colors, it's a bit harder than that. 

![pwsh-old-cropped-censored](https://user-images.githubusercontent.com/357902/126886673-09a7080f-21f6-48f6-8abf-f6c280a42593.png)

When you have something like f.lux on, it can be almost illegible if you forget to shut it off for your terminal app--and if you normally don't do this, why would you? (I tried to capture this with a screenshot but the colors are getting mangled right now).

Yellow on black and yellow on blue, though, both read easily. 

![cmd-new-for-real_cropped_censored](https://user-images.githubusercontent.com/357902/126887360-f5f50a97-e110-4d4b-afdb-e0cfa301a2be.png)

![pwsh-new-cropped-censored](https://user-images.githubusercontent.com/357902/126887285-a1e8670d-45da-4e8c-a6d4-32655408d03d.png)

Seems like an easy quality-of-life win. (Screenshots censored to remove my user and host, but I have also changed the code so that their colors are also changed from blue to yellow.)

