### PR TITLE
Show missing "winget" identifier in package count.

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -805,7 +805,7 @@ function info_pkgs {
         $wingetpkg = (winget list | Where-Object {$_.Trim("`n`r`t`b-\|/ ").Length -ne 0} | Measure-Object).Count - 1
 
         if ($wingetpkg) {
-            $pkgs += "$wingetpkg"
+            $pkgs += "$wingetpkg (winget)"
         }
     }
 


### PR DESCRIPTION
The choco and scoop packages count both have the package manager identifier written next to it, but winget is missing it. This adds the identifier to keep the output consistent, if users explicitly enable winget in settings.