### PR TITLE
Add `made with: wordpad` badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img alt="GitHub code size in bytes" src="https://img.shields.io/github/languages/code-size/kiedtl/winfetch.svg">
 <img alt="GitHub license" src="https://img.shields.io/github/license/kiedtl/winfetch.svg">
 <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/kiedtl/winfetch.svg">
+<img alt="Made with: Wordpad" src="https://img.shields.io/badge/made%20with-wordpad-blue.svg">
 </p>
 
 <br />


### PR DESCRIPTION
It's funny because it's true. Winfetch was created in late 2018/2019 with Wordpad because my school had blocked Emacs/VSCode/Atom. I don't recall the reason for not using Notepad.