### PR TITLE
Fix multi gpu not on separate lines

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1046,8 +1046,7 @@ foreach ($item in $config) {
                 if (-not $stripansi) {
                     # move cursor to column 40
                     $output = "$e[40G$output"
-                }
-                else {
+                } else {
                     # write image progressively
                     $imgline = ("$($img[$writtenLines])" -replace $ansiRegex, "").PadRight($COLUMNS)
                     $output = " $imgline   $output"
@@ -1061,8 +1060,7 @@ foreach ($item in $config) {
                 if ($output.Length -gt $freeSpace) {
                     $output = $output.Substring(0, $output.Length - ($output.Length - $freeSpace))
                 }
-            }
-            else {
+            } else {
                 $output = truncate_line $output $freeSpace
             }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1019,8 +1019,7 @@ if ($img -and -not $stripansi) {
 foreach ($item in $config) {
     if (Test-Path Function:"info_$item") {
         $info = & "info_$item"
-    }
-    else {
+    } else {
         $info = @{ title = "$e[31mfunction 'info_$item' not found" }
     }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -74,7 +74,7 @@ param(
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$memorystyle = "text",
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$diskstyle = "text",
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$batterystyle = "text",
-    [array]$showdisks = @("*"),
+    [array]$showdisks = @($env:SystemDrive),
     [array]$showpkgs = @("scoop", "choco")
 )
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -705,9 +705,9 @@ function info_cpu {
 function info_gpu {
     [System.Collections.ArrayList]$lines = @()
     #loop through Win32_VideoController
-    foreach ($gpu in Get-CimInstance -ClassName Win32_VideoController -CimSession $cimSession) {
+    foreach ($gpu in Get-CimInstance -ClassName Win32_VideoController -Property Name -CimSession $cimSession) {
         [void]$lines.Add(@{
-        title   = "GPU"
+            title   = "GPU"
             content = $gpu.Name
         })
     }

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1037,37 +1037,37 @@ foreach ($item in $config) {
     }
 
     foreach ($line in $info) {
-            $output = "$e[1;33m$($line["title"])$e[0m"
+        $output = "$e[1;33m$($line["title"])$e[0m"
 
-            if ($line["title"] -and $line["content"]) {
-                $output += ": "
-            }
+        if ($line["title"] -and $line["content"]) {
+            $output += ": "
+        }
 
         $output += "$($line["content"])"
 
-            if ($img) {
-                if (-not $stripansi) {
-                    # move cursor to column 40
-                    $output = "$e[40G$output"
-                } else {
-                    # write image progressively
-                $imgline = ("$($img[$writtenLines])"  -replace $ansiRegex, "").PadRight($COLUMNS)
-                    $output = " $imgline   $output"
-                }
-            }
-
-            $writtenLines++
-
-            if ($stripansi) {
-                $output = $output -replace $ansiRegex, ""
-                if ($output.Length -gt $freeSpace) {
-                    $output = $output.Substring(0, $output.Length - ($output.Length - $freeSpace))
-                }
+        if ($img) {
+            if (-not $stripansi) {
+                # move cursor to right of image
+                $output = "$e[$(2 + $COLUMNS + $GAP)G$output"
             } else {
-                $output = truncate_line $output $freeSpace
+                # write image progressively
+                $imgline = ("$($img[$writtenLines])"  -replace $ansiRegex, "").PadRight($COLUMNS)
+                $output = " $imgline   $output"
             }
+        }
 
-            Write-Output $output
+        $writtenLines++
+
+        if ($stripansi) {
+            $output = $output -replace $ansiRegex, ""
+            if ($output.Length -gt $freeSpace) {
+                $output = $output.Substring(0, $output.Length - ($output.Length - $freeSpace))
+            }
+        } else {
+            $output = truncate_line $output $freeSpace
+        }
+
+        Write-Output $output
     }
 }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -703,10 +703,15 @@ function info_cpu {
 }
 
 function info_gpu {
-    return @{
+    [System.Collections.ArrayList]$lines = @()
+    #loop through Win32_VideoController
+    foreach ($gpu in Get-CimInstance -ClassName Win32_VideoController -CimSession $cimSession) {
+        [void]$lines.Add(@{
         title   = "GPU"
-        content = (Get-CimInstance -ClassName Win32_VideoController -Property Name -CimSession $cimSession).Name
+            content = $gpu.Name
+        })
     }
+    return $lines
 }
 
 
@@ -1032,14 +1037,13 @@ foreach ($item in $config) {
     }
 
     foreach ($line in $info) {
-        foreach ($item in $line["content"]) {
             $output = "$e[1;33m$($line["title"])$e[0m"
 
             if ($line["title"] -and $line["content"]) {
                 $output += ": "
             }
 
-            $output += $item
+        $output += "$($line["content"])"
 
             if ($img) {
                 if (-not $stripansi) {
@@ -1047,7 +1051,7 @@ foreach ($item in $config) {
                     $output = "$e[40G$output"
                 } else {
                     # write image progressively
-                    $imgline = ("$($img[$writtenLines])" -replace $ansiRegex, "").PadRight($COLUMNS)
+                $imgline = ("$($img[$writtenLines])"  -replace $ansiRegex, "").PadRight($COLUMNS)
                     $output = " $imgline   $output"
                 }
             }
@@ -1064,7 +1068,6 @@ foreach ($item in $config) {
             }
 
             Write-Output $output
-        }
     }
 }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -74,7 +74,7 @@ param(
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$memorystyle = "text",
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$diskstyle = "text",
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$batterystyle = "text",
-    [array]$showdisks = @($env:SystemDrive),
+    [array]$showdisks = @("*"),
     [array]$showpkgs = @("scoop", "choco")
 )
 
@@ -984,7 +984,8 @@ if ($img -and -not $stripansi) {
 foreach ($item in $config) {
     if (Test-Path Function:"info_$item") {
         $info = & "info_$item"
-    } else {
+    }
+    else {
         $info = @{ title = "$e[31mfunction 'info_$item' not found" }
     }
 
@@ -997,37 +998,41 @@ foreach ($item in $config) {
     }
 
     foreach ($line in $info) {
-        $output = "$e[1;33m$($line["title"])$e[0m"
+        foreach ($item in $line["content"]) {
+            $output = "$e[1;33m$($line["title"])$e[0m"
 
-        if ($line["title"] -and $line["content"]) {
-            $output += ": "
-        }
-
-        $output += "$($line["content"])"
-
-        if ($img) {
-            if (-not $stripansi) {
-                # move cursor to column 40
-                $output = "$e[40G$output"
-            } else {
-                # write image progressively
-                $imgline = ("$($img[$writtenLines])"  -replace $ansiRegex, "").PadRight($COLUMNS)
-                $output = " $imgline   $output"
+            if ($line["title"] -and $line["content"]) {
+                $output += ": "
             }
-        }
 
-        $writtenLines++
+            $output += $item
 
-        if ($stripansi) {
-            $output = $output -replace $ansiRegex, ""
-            if ($output.Length -gt $freeSpace) {
-                $output = $output.Substring(0, $output.Length - ($output.Length - $freeSpace))
+            if ($img) {
+                if (-not $stripansi) {
+                    # move cursor to column 40
+                    $output = "$e[40G$output"
+                }
+                else {
+                    # write image progressively
+                    $imgline = ("$($img[$writtenLines])" -replace $ansiRegex, "").PadRight($COLUMNS)
+                    $output = " $imgline   $output"
+                }
             }
-        } else {
-            $output = truncate_line $output $freeSpace
-        }
 
-        Write-Output $output
+            $writtenLines++
+
+            if ($stripansi) {
+                $output = $output -replace $ansiRegex, ""
+                if ($output.Length -gt $freeSpace) {
+                    $output = $output.Substring(0, $output.Length - ($output.Length - $freeSpace))
+                }
+            }
+            else {
+                $output = truncate_line $output $freeSpace
+            }
+
+            Write-Output $output
+        }
     }
 }
 


### PR DESCRIPTION
This is how `neofetch` showing multiple gpus
![image](https://user-images.githubusercontent.com/42881734/152558662-074e53fa-f410-49fa-a0a0-689d45ae3642.png)

This is how `winfetch` showing multiple gpus before this change
![image](https://user-images.githubusercontent.com/42881734/152558794-fa4e7c27-8d36-48ce-a0b8-f51a5be121af.png)

This is after this change
![image](https://user-images.githubusercontent.com/42881734/152558873-4bda9f58-21b1-411a-ae78-25feb7870b51.png)
