### PR TITLE
Use unicode blocks for windows 11 logo

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -398,23 +398,23 @@ $img = if (-not $noimage) {
         }
 
         if ($logo -eq "Windows 11") {
-            $COLUMNS = 32
+            $COLUMNS = 31
             @(
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34m                                 "
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
-                "${e}[${t};34mlllllllllllllll   lllllllllllllll"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m                                "
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
+                "${e}[${t};34m███████████████  ███████████████"
             )
         } elseif ($logo -eq "Windows 10" -Or $logo -eq "Windows 8.1" -Or $logo -eq "Windows 8") {
             $COLUMNS = 34


### PR DESCRIPTION
Just looks better to me. If someone likes the ascii version better though, I'd be happy to work it into an optional version or something.
### Before
![image](https://user-images.githubusercontent.com/7019130/168487317-3649077f-3be7-4162-81f7-f1a4a81db079.png)

### After
![image](https://user-images.githubusercontent.com/7019130/168487206-1d27408e-cc8c-48a6-b77f-4f190c8f4dde.png)