### PR TITLE
Fixed an error when executing with the OSS version of PowerShell

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -859,12 +859,12 @@ function info_pkgs {
         }
     }
 
-    foreach ($pkgitem in $CustomPkgs) {
-        if (Test-Path Function:"info_pkg_$pkgitem") {
-            $count = & "info_pkg_$pkgitem"
-            $pkgs += "$count ($pkgitem)"
-        }
-    }
+    #foreach ($pkgitem in $CustomPkgs) {
+    #    if (Test-Path Function:"info_pkg_$pkgitem") {
+    #        $count = & "info_pkg_$pkgitem"
+    #        $pkgs += "$count ($pkgitem)"
+    #    }
+    #}
 
     if (-not $pkgs) {
         $pkgs = "(none)"


### PR DESCRIPTION
I had no problem with Windows PowerShell, but when I ran it with the OSS version of PowerShell (v.7.2.4), I got the following error, so I examined the source.


```pwsh
InvalidOperation: C:\Users\username\scoop\apps\winfetch\current\winfetch.ps1:862
Line |
 862 |      foreach ($pkgitem in $CustomPkgs) {
     |                           ~~~~~~~~~~~
     | The variable '$CustomPkgs' cannot be retrieved because it has not been set.
```

I found that the $CustomPkgs variable in line 962 of winfetch.ps1 was not used and running it as is caused the error, so I commented it out.