### PR TITLE
Fix Resolution Bug

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -617,8 +617,11 @@ function info_uptime {
 # ===== RESOLUTION =====
 function info_resolution {
     Add-Type -AssemblyName System.Windows.Forms
-    $displays = foreach ($monitor in [System.Windows.Forms.Screen]::AllScreens) {
-        "$($monitor.Bounds.Size.Width)x$($monitor.Bounds.Size.Height)"
+    $monitors = [System.Windows.Forms.Screen]::AllScreens
+    $scale = (Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorBasicDisplayParams -CimSession $cimSession).DisplayTransferCharacteristic / 96
+
+    $displays = for($i = 0;$i -lt $monitors.Length;$i++){
+        "$($monitors[$i].Bounds.Size.Width * $scale[$i])x$($monitors[$i].Bounds.Size.Height * $scale[$i])"
     }
 
     return @{


### PR DESCRIPTION
Uses Get-CimInstance fix #76 without creating a massive speed decrease

Closes #76 :
- Gets the current resolution scale by getting DisplayTransferCharacteristic from WmiMonitorBasicDisplayParams
  - Divides by 96 to get the scale from the given PPI
  - ~2x Slower than the current (but broken) implementation w/o PowerShell bottleneck
    - 34 ms -> 84 ms
  - ~2.7x Faster than #131 w/o PowerShell bottleneck
    - 230 ms -> 84 ms

Possible avenues for speedup:
- HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\Configuration stores multi-display configurations, including resolution, but requires admin to access
  - Maybe check if current instance is elevated
- HKEY_CURRENT_USER\Control Panel\Desktop\WindowMetrics has a DPI value but not per-monitor DPI
  - It is used in Windows 8.1 and before as per-display scaling was added in Windows 10
    - Maybe add a Windows version check
- Get-CimInstance -ClassName Win32_VideoController gives resolution, but only for one monitor per video adapter
  - Could use [System.Windows.Forms.SystemInformation]::MonitorCount to check if there's only one monitor connected