### PR TITLE
Implement Faster IPv4 Address Retrieval Method

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1380,16 +1380,16 @@ function info_weather {
 function info_local_ip {
     try {
         # Get all network adapters
-        foreach ($ni in [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()){
+        foreach ($ni in [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()) {
             # Get the IP information of each adapter
             $properties = $ni.GetIPProperties()
             # Check if the adapter is online, has a gateway address, and the adapter does not have a loopback address
-            if($ni.OperationalStatus -eq 'Up' -and !($null -eq $properties.GatewayAddresses[0]) -and !$properties.GatewayAddresses[0].Address.ToString().Equals("0.0.0.0")){
+            if ($ni.OperationalStatus -eq 'Up' -and !($null -eq $properties.GatewayAddresses[0]) -and !$properties.GatewayAddresses[0].Address.ToString().Equals("0.0.0.0")) {
                 # Check if adapter is a WiFi or Ethernet adapter
-                if ($ni.NetworkInterfaceType -eq "Wireless80211" -or $ni.NetworkInterfaceType -eq "Ethernet"){
-                    foreach ($ip in $properties.UnicastAddresses){
-                        if ($ip.Address.AddressFamily -eq "InterNetwork"){
-                            if(!$local_ip){$local_ip = $ip.Address.ToString()}
+                if ($ni.NetworkInterfaceType -eq "Wireless80211" -or $ni.NetworkInterfaceType -eq "Ethernet") {
+                    foreach ($ip in $properties.UnicastAddresses) {
+                        if ($ip.Address.AddressFamily -eq "InterNetwork") {
+                            if (!$local_ip) { $local_ip = $ip.Address.ToString() }
                         }
                     }
                 }


### PR DESCRIPTION
- Implemented a new method to find the user's actual IPv4 address using a recursive mess of .NET witchcraft that somehow ends up being much faster
  - Uses a combination of C# scripts at [https://stackoverflow.com/questions/8089685/c-sharp-finding-my-machines-local-ip-address-and-not-the-vms/25553311](url) which I converted to PowerShell
  - Gets all network adapters using `[System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()`
    - Checks if each adapter is online, has a gateway address, and is not a loopback adapter
      - Then checks if the adapter is a WiFi or Ethernet adapter using `NetworkInterfaceType`
        - _Then_ iterates through each Unicast address, and checks if the address is for InterNetwork communication
          - **Then** checks if the $local_ip variable has already been set, and if not, sets it to the IP returned
            - This is because, under some circumstances, multiple IPs can be returned
              - It grabbed the ZeroTier IP address on my PC, which shouldn't occur
              - This bug also exists with the previous implementation, and I'm not sure if there is an easy way to fix it without manually filtering out specific adapter names

Speed:
- PowerShell 5:
  - 400ms → 43ms
    - 9.3x Faster
- PowerShell 7:
  - 459ms → 56ms
    - 8.2x Faster

Bottlenecked Speed:
- PowerShell 5:
  - 1446ms → 321ms
    - 4.5x Faster
- PowerShell 7:
  - 1673ms → 313ms
    - 6.3x Faster