### PR TITLE
Speed Up info_pkgs

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -889,7 +889,7 @@ function info_pkgs {
     }
 
     if ("choco" -in $ShowPkgs -and (Get-Command -Name choco -ErrorAction Ignore)) {
-        $chocopkg = (& clist -l)[-1].Split(' ')[0] - 1
+        $chocopkg = (Get-ChildItem -Path "$env:ChocolateyInstall\lib").count - 1
 
         if ($chocopkg) {
             $pkgs += "$chocopkg (choco)"


### PR DESCRIPTION
Speeds up the retrieval of packages

- [ x ] Speed up Chocolatey
  - Gets the quantity of folders at `$env:ChocolateyInstall\lib`, which contains the programs Chocolatey has installed.
  - ~681ms -> 20ms
    - 34x Faster
- [ ] Speed up WinFetch
- [ ] Speed up Scoop