### PR TITLE
Optimize ps_pkgs

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -848,8 +848,24 @@ function info_pwsh {
 function info_ps_pkgs {
     $ps_pkgs = @()
 
-    $modulecount = (Get-InstalledModule).Length
-    $scriptcount = (Get-InstalledScript).Length
+    # Get all installed Packages
+    $pkgs = Get-Package
+
+    # Replicate the behavior of the PowerShellGet module, revoving other information gathering we don't need
+    $modulecount = ($pkgs.foreach{
+        foreach($swid in $_){
+            ($swid.Metadata["tags"] -split " ") | ForEach-Object {
+                $_.where({$_ -contains "PSModule"})
+            }
+        }
+    }).Count
+    $scriptcount = ($pkgs.foreach{
+        foreach($swid in $_){
+            ($swid.Metadata["tags"] -split " ") | ForEach-Object {
+                $_.where({$_ -contains "PSScript"})
+            }
+        }
+    }).Count
 
     if ($modulecount) {
         if ($modulecount -eq 1) { $modulestring = "1 Module" }

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -853,17 +853,13 @@ function info_ps_pkgs {
 
     # Replicate the behavior of the PowerShellGet module, revoving other information gathering we don't need
     $modulecount = ($pkgs.foreach{
-        foreach($swid in $_){
-            ($swid.Metadata["tags"] -split " ") | ForEach-Object {
-                $_.where({$_ -contains "PSModule"})
-            }
+        ($_.Metadata["tags"] -split " ").foreach{
+            $_.where({$_ -contains "PSModule"})
         }
     }).Count
     $scriptcount = ($pkgs.foreach{
-        foreach($swid in $_){
-            ($swid.Metadata["tags"] -split " ") | ForEach-Object {
-                $_.where({$_ -contains "PSScript"})
-            }
+        ($_.Metadata["tags"] -split " ").foreach{
+            $_.where({$_ -contains "PSScript"})
         }
     }).Count
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -851,7 +851,7 @@ function info_ps_pkgs {
     # Get all installed Packages
     $pkgs = Get-Package
 
-    # Replicate the behavior of the PowerShellGet module, revoving other information gathering we don't need
+    # Replicate the behavior of the PowerShellGet module, removing other information gathering we don't need
     $modulecount = ($pkgs.foreach{
         ($_.Metadata["tags"] -split " ").foreach{
             $_.where({$_ -contains "PSModule"})


### PR DESCRIPTION
- Replicates the functionality of `Get-InstalledModule` and `Get-InstalledScript`, which apply some filters to Get-Package
  - Has a slight speed increase with Modules, and a slight speed decrease with Scripts
    - I suspect it has something to do with the quantity of modules or scripts that are found, as for me no scripts are installed and some modules are
  - Largest speed increase comes from the reuse of `Get-Package`'s output

Speed (Will populate later):
- PowerShell 5:
  - ms → ms
    - 
- PowerShell 7:
  - ms → ms
    - 

Bottlenecked Speed:
- PowerShell 5:
  - 3962ms → 3771ms
    - 5.06% Faster
- PowerShell 7:
  - 5800ms → 5289ms
    - 9.66% Faster